### PR TITLE
Fix boostrap script

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -123,6 +123,7 @@ macnsenter () {
 
 macreadlink () {
 	echo 'Installing coreutils'
+	#Installs 'greadlink' tool
 	brew install coreutils
 }
 


### PR DESCRIPTION
I tried to run the boostrap script and ran into some errors. This PR fixes those errors:

-  One `chown` command had a typo
- `mktemp` doesn't have the `-p` option on MacOS
- `readlink` doesn't have the `-f`option on MacOS