### PR TITLE
Fix local dashboard setup

### DIFF
--- a/packages/transmute-cli/package.json
+++ b/packages/transmute-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transmute-cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "transmute cli",
   "scripts": {
     "transmute": "./src/index.js",

--- a/packages/transmute-cli/src/commands/init/initializer
+++ b/packages/transmute-cli/src/commands/init/initializer
@@ -189,7 +189,7 @@ echo 'GANACHE HEALTHCHECK'
 echo "https://ganache.transmute.minikube:$KONG_PROXY_PORT"
 
 curl -s -k -X POST \
-  --url "https://ganache.transmute.minikube:$KONG_PROXY_PORT/ganache" \
+  --url "https://ganache.transmute.minikube:$KONG_PROXY_PORT" \
   --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":68}' \
   | jq -r '.'
 

--- a/packages/transmute-dashboard/README.md
+++ b/packages/transmute-dashboard/README.md
@@ -13,6 +13,20 @@ npm run truffle:migrate
 npm run start
 ```
 
+### Testing With Transmute CLI
+
+The transmute CLI helps manage a local minikube environment which is more similar to production environments such as GKE, Azure or AWS.
+
+In order to develop against services hosted in this environment, some changes are necessary:
+
+Migrate contracts to ganahce hosted in minikube:
+
+```
+NODE_TLS_REJECT_UNAUTHORIZED='0' TRANSMUTE_ENV='minikube' npm run truffle:migrate   
+```
+
+Edit `./src/transmute-config/index.js` make set `transmute.network` to `minikube`
+
 ### Deployment
 
 This is for contributors only.

--- a/packages/transmute-dashboard/contracts/ESigner.sol
+++ b/packages/transmute-dashboard/contracts/ESigner.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.4.19;
 
 import "transmute-framework/contracts/EventStore.sol";
+import "transmute-framework/contracts/EventStoreFactory.sol";
 
 contract ESigner is EventStore {
 


### PR DESCRIPTION
This addresses https://github.com/transmute-industries/transmute/issues/155

We want to verify that users can use the environment created by the cli, and that all network dependencies are contained in minikube for the e-signer demo.

The setup process should be documented as follows:

```
source <(curl -Ls https://git.io/transmute_bootstrap)
transmute k8s provision-minikube my-cluster
transmute k8s init my-cluster
cd ~/.transmute/git/transmute/packages/transmute-dashboard
NODE_TLS_REJECT_UNAUTHORIZED='0' TRANSMUTE_ENV='minikube' npm run truffle:migrate  
# Edit `./src/transmute-config/index.js` make set `transmute.network` to `minikube`

npm run start
```

ESigner demo should work, and should use ganache and ipfs from cluster setup by cli.

no networks requests to infura should be visible in console.

