### PR TITLE
[WIP] fix bootstrap for macOS

### DIFF
--- a/packages/transmute-cli/components/ansible/roles/ipfs/tasks/main.yml
+++ b/packages/transmute-cli/components/ansible/roles/ipfs/tasks/main.yml
@@ -4,7 +4,7 @@
   register: output
 
 - name: install ipfs
-  shell: "helm install $(npm root -g)/transmute-cli/components/ipfs/ --name decentralized-storage --wait"
+  shell: "helm install stable/ipfs --name decentralized-storage"
   when: not output.stdout
 
 - name: ready.w8 decentralized-storage-ipfs

--- a/packages/transmute-cli/src/commands/init/index.js
+++ b/packages/transmute-cli/src/commands/init/index.js
@@ -1,11 +1,9 @@
 const run = require('../runner');
 
-const path = require('path');
-
-module.exports.k8s = (dryrun, clusterName) => {
+module.exports.k8s = (dryrun) => {
   let prov_cmd = 'ansible-playbook --diff -l "localhost" ' +
     __dirname +
-    '/../../../components/ansible/init.yml -e ' + clusterName;
+    '/../../../components/ansible/init.yml';
 
   if (dryrun == 'true') {
     console.info('<--dry run-->');

--- a/packages/transmute-cli/src/commands/provision/index.js
+++ b/packages/transmute-cli/src/commands/provision/index.js
@@ -1,107 +1,123 @@
 const run = require('../runner');
 const logger = require('../../logger');
-const TRANSMUTE_KUBE_VERSION = process.env.TRANSMUTE_KUBE_VERSION || 'v1.9.0';
+const TRANSMUTE_KUBE_VERSION = process.env.TRANSMUTE_KUBE_VERSION || 'v1.9.4';
 const MINIKUBE_CPU = process.env.MINIKUBE_CPU || '4';
 const MINIKUBE_MEMORY = process.env.MINIKUBE_MEMORY || '4096';
 const MINIKUBE_DISK = process.env.MINIKUBE_DISK || '100g';
-const MINIKUBE_PROFILE = process.env.MINIKUBE_PROFILE || 'transmute-k8s';
 const MINIKUBE_DRIVERS = ['virtualbox', 'kvm', 'kvm2', 'none'];
 
-module.exports.minikube = (dryrun, clusterName, minikubeDriver) => {
-    let minikube_param =
-        ' -e kubernetes_version=' +
-        TRANSMUTE_KUBE_VERSION +
-        ' -e minikube_disk_size=' +
-        MINIKUBE_DISK +
-        ' -e minikube_cpus=' +
-        MINIKUBE_CPU +
-        ' -e minikube_memory=' +
-        MINIKUBE_MEMORY;
-    +' -e minikube_profile=' + MINIKUBE_PROFILE;
+module.exports.minikube = (
+  dryrun,
+  kubernetesVersion,
+  minikubeDriver
+) => {
+  let minikube_param =
+    ' -e minikube_disk_size=' +
+    MINIKUBE_DISK +
+    ' -e minikube_cpus=' +
+    MINIKUBE_CPU +
+    ' -e minikube_memory=' +
+    MINIKUBE_MEMORY;
 
-    let prov_cmd =
-        'ansible-playbook --diff -l "localhost" ' +
-        __dirname +
-        '/../../../components/ansible/provision-minikube.yml';
+  if (kubernetesVersion) {
+    minikube_param = minikube_param +
+      ' -e kubernetes_version=' +
+      kubernetesVersion;
+  } else {
+    minikube_param = minikube_param +
+      ' -e kubernetes_version=' +
+      TRANSMUTE_KUBE_VERSION;
+  }
 
-    if (MINIKUBE_DRIVERS.indexOf(minikubeDriver) == -1) {
-        minikubeDriver = 'none';
+  if (MINIKUBE_DRIVERS.indexOf(minikubeDriver) == -1) {
+    if (process.platform === 'linux') {
+      minikubeDriver = 'none';
+    } else {
+      minikubeDriver = 'virtualbox';
     }
+  }
 
-    if (minikubeDriver == 'none') {
-        logger.log({
-            level: 'info',
-            message: `VMDriver=None requires minikube to run as root!`,
-        });
-    }
+  if (minikubeDriver == 'none') {
+    logger.log({
+      level: 'info',
+      message: '\"--vmdriver \'none\'\" requires minikube to run as root on Linux.'
+    });
+  }
 
-    prov_cmd = prov_cmd + ' -e minikube_vm_driver=' + minikubeDriver;
+  minikube_param = minikube_param +
+    ' -e minikube_vm_driver=' +
+    minikubeDriver;
 
-    prov_cmd = prov_cmd + minikube_param;
-    if (dryrun === 'true') {
-        console.info('<--dry run-->');
-        prov_cmd = prov_cmd + ' --check';
-    }
-    run.shellExec(prov_cmd);
+  let prov_cmd =
+    'ansible-playbook --diff -l "localhost" ' +
+    __dirname +
+    '/../../../components/ansible/provision-minikube.yml' +
+    minikube_param;
+
+  if (dryrun === 'true') {
+    console.info('<--dry run-->');
+    prov_cmd = prov_cmd + ' --check';
+  }
+  run.shellExec(prov_cmd);
 };
 
 module.exports.aks = (
-    dryrun,
-    myResourceGroup,
-    myAKSCluster,
-    myNodeCount,
-    myNodeSize,
-    GenSSHKeys,
+  dryrun,
+  myResourceGroup,
+  myAKSCluster,
+  myNodeCount,
+  myNodeSize,
+  GenSSHKeys,
 ) => {
-    let prov_cmd_asible =
-        'ansible-playbook --diff -l "localhost" ' +
-        __dirname +
-        '/../../../components/ansible/provision-azure.yml';
+  let prov_cmd_asible =
+    'ansible-playbook --diff -l "localhost" ' +
+    __dirname +
+    '/../../../components/ansible/provision-azure.yml';
 
-    let gensshkeys_opt = '';
-    if (GenSSHKeys) {
-        gensshkeys_opt = '"--generate-ssh-keys"';
-    }
-    if (myAKSCluster == undefined) {
-        throw 'You need to define a clustername';
-    } else {
-        var akscluster_opt = '"--name ' + myAKSCluster + '"';
-    }
-    if (myNodeCount == undefined) {
-        throw 'You need to define a number of nodes';
-    } else {
-        var nodes_opt = '"--node-count ' + myNodeCount + '"';
-    }
-    if (myNodeSize == undefined) {
-        console.warn('no size given using default');
-        var nodesize_opt = '';
-    } else {
-        var nodesize_opt = '"--node-vm-size ' + myNodeSize + '"';
-    }
-    if (myResourceGroup == undefined) {
-        throw 'You need to define a group';
-    } else {
-        var group_opt = '"--resource-group ' + myResourceGroup + '"';
-    }
+  let gensshkeys_opt = '';
+  if (GenSSHKeys) {
+    gensshkeys_opt = '"--generate-ssh-keys"';
+  }
+  if (myAKSCluster == undefined) {
+    throw 'You need to define a clustername';
+  } else {
+    var akscluster_opt = '"--name ' + myAKSCluster + '"';
+  }
+  if (myNodeCount == undefined) {
+    throw 'You need to define a number of nodes';
+  } else {
+    var nodes_opt = '"--node-count ' + myNodeCount + '"';
+  }
+  if (myNodeSize == undefined) {
+    console.warn('no size given using default');
+    var nodesize_opt = '';
+  } else {
+    var nodesize_opt = '"--node-vm-size ' + myNodeSize + '"';
+  }
+  if (myResourceGroup == undefined) {
+    throw 'You need to define a group';
+  } else {
+    var group_opt = '"--resource-group ' + myResourceGroup + '"';
+  }
 
-    let aksParams =
-        ' -e dryrun=' +
-        dryrun +
-        ' -e group_opt=' +
-        group_opt +
-        ' -e akscluster_opt=' +
-        akscluster_opt +
-        ' -e nodes_opt=' +
-        nodes_opt +
-        ' -e nodesize_opt=' +
-        nodesize_opt +
-        ' -e gensshkeys_opt=' +
-        gensshkeys_opt;
+  let aksParams =
+    ' -e dryrun=' +
+    dryrun +
+    ' -e group_opt=' +
+    group_opt +
+    ' -e akscluster_opt=' +
+    akscluster_opt +
+    ' -e nodes_opt=' +
+    nodes_opt +
+    ' -e nodesize_opt=' +
+    nodesize_opt +
+    ' -e gensshkeys_opt=' +
+    gensshkeys_opt;
 
-    let prov_cmd_azure = prov_cmd_asible + aksParams;
-    if (dryrun === 'true') {
-        console.info('<--dry run-->');
-        prov_cmd_azure = prov_cmd_azure + ' --check';
-    }
-    run.shellExec(prov_cmd_azure);
+  let prov_cmd_azure = prov_cmd_asible + aksParams;
+  if (dryrun === 'true') {
+    console.info('<--dry run-->');
+    prov_cmd_azure = prov_cmd_azure + ' --check';
+  }
+  run.shellExec(prov_cmd_azure);
 };

--- a/packages/transmute-cli/src/index.js
+++ b/packages/transmute-cli/src/index.js
@@ -180,11 +180,11 @@ vorpal
   });
 
 /** transmute k8s  init initializes a cluster with the transmute framework
- * @name transmute k8s init <clustername>
- * @example transmute k8s init myClusterName
+ * @name transmute k8s init
+ * @example transmute k8s init
  * */
 vorpal
-  .command('k8s init <clustername>')
+  .command('k8s init')
   .description('Initialize k8s cluster')
   .option('--dryrun', 'Print out what would be done without executing anything')
   .action(function(args, callback) {
@@ -194,7 +194,7 @@ vorpal
     if (args.options.dryrun) {
       dryrun = 'true';
     }
-    init.k8s(dryrun, args.clustername);
+    init.k8s(dryrun);
     // end performance test
     var t1 = performance.now();
     vorpal.logger.info(
@@ -257,14 +257,18 @@ vorpal
   });
 
 /** transmute k8s provision-minikube uses minikube to provision a k8s cluster
- * @name transmute k8s provision-minikube <clustername>
- * @example transmute k8s provision-minikube myClusterName
+ * @name transmute k8s provision-minikube
+ * @example transmute k8s provision-minikube
  * @param {string} clustername
  * */
 vorpal
-  .command('k8s provision-minikube <clustername>')
+  .command('k8s provision-minikube')
   .description('Provision k8s cluster')
   .option('--nodes <nodes>', 'How many nodes to create the cluster with')
+  .option(
+    '--kubernetesVersion <kubernetesVersion>',
+    'Kubernetes version to create the cluster with; defaults to "v.1.9.4"'
+  )
   .option(
     '--vmdriver <vmdriver>',
     'The cluster name to create the cluster with'
@@ -278,10 +282,12 @@ vorpal
       console.info('dry run');
       dryrun = 'true';
     }
-    if (args.options.vmdriver) {
-      provision.minikube(dryrun, args.clustername, args.options.vmdriver);
+    if (args.options.kubernetesVersion && args.options.vmdriver) {
+      provision.minikube(dryrun, args.options.kubernetesVersion, args.options.vmdriver);
+    } else if (args.options.kubernetesVersion) {
+      provision.minikube(dryrun, args.options.kubernetesVersion);
     } else {
-      provision.minikube(dryrun, args.clustername);
+      provision.minikube(dryrun);
     }
     // end performance test
     var t1 = performance.now();


### PR DESCRIPTION
The bootstrap process for the Transmute monorepo has issues on macOS.

Tested on OS X 10.13, this PR fixes macOS bootstrap behavior by updating the `transmute k8s init` and `transmute k8s provision-minikube` commands.

For `transmute k8s init`:
  • Removes `clusterName` argument for the time being, as it is not currently used.

For `transmute k8s provision-minikube`:
  • Removes `clusterName` argument for the time being, as it is not currently used.
  • Adds `--kubernetesVersion` optional argument.