### PR TITLE
[WIP] Feat/eng 663 command for installing the istio microservice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,13 @@ before_script:
   - npm i
   - npm i -g
   - cd $TRAVIS_BUILD_DIR
-  - transmute k8s provision-minikube travis_test_cluster
-  - transmute k8s init travis_test_cluster
-  - transmute k8s microservice install elasticsearch
-  - transmute k8s microservice install ganache
+  - transmute k8s provision-minikube
+  - transmute k8s init
+  - transmute k8s microservice install istio
   - transmute k8s microservice install kong
+  - transmute k8s microservice install ganache
   - transmute k8s microservice install ipfs
+  - transmute k8s microservice install elasticsearch
   - transmute debug
 
 script:

--- a/ansible-playbook/roles/dependencies/tasks/linux.yml
+++ b/ansible-playbook/roles/dependencies/tasks/linux.yml
@@ -74,7 +74,7 @@
 
 - name: install minikube
   get_url:
-    url: "https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-linux-amd64"
+    url: "https://storage.googleapis.com/minikube/releases/v0.28.2/minikube-linux-amd64"
     dest: "/usr/local/bin/minikube"
     remote_src: yes
     mode: 0755
@@ -90,7 +90,7 @@
 
 - name: Unarchive helm
   unarchive:
-    src: "https://storage.googleapis.com/kubernetes-helm/helm-v2.8.2-linux-amd64.tar.gz"
+    src: "https://storage.googleapis.com/kubernetes-helm/helm-v2.10.0-linux-amd64.tar.gz"
     dest: "{{ tmp.path }}"
     remote_src: yes
 

--- a/ansible-playbook/transmute.yml
+++ b/ansible-playbook/transmute.yml
@@ -2,7 +2,7 @@
 - name: transmute
   vars:
     fix_dotfiles: true
-    transmute_kube_version: "v1.9.4"
+    transmute_kube_version: "v1.11.3"
     nvm_version: "v0.33.11"
   hosts: localhost
   connection: local

--- a/packages/transmute-cli/components/ansible/k8s-install-istio.yml
+++ b/packages/transmute-cli/components/ansible/k8s-install-istio.yml
@@ -16,8 +16,9 @@
         flags: >-
           --set "gateways.istio-ingressgateway.type=NodePort"
           --set "gateways.istio-egressgateway.type=NodePort"
+          --no-crd-hook
         crds:
-          path: "install/kubernetes/helm/istio/crds.yaml"
+          path: "install/kubernetes/helm/istio/templates/crds.yaml"
           apply_before_install: yes
   roles:
     - role: k8s-install-microservice-with-local-helm-chart

--- a/packages/transmute-cli/components/ansible/k8s-install-istio.yml
+++ b/packages/transmute-cli/components/ansible/k8s-install-istio.yml
@@ -1,0 +1,20 @@
+---
+- name: k8s-install-istio
+  hosts: localhost
+  connection: local
+  gather_facts: yes
+  vars:
+    microservice:
+      name: istio
+      namespace: istio-system
+      release:
+        dest: "{{ ansible_env.HOME }}/.transmute/git/istio"
+        repo: "https://github.com/istio/istio.git"
+        version: "1.0.2"
+        chart:
+          path: "install/kubernetes/helm/istio"
+          flags: >-
+            --set "gateways.istio-ingressgateway.type=NodePort"
+            --set "gateways.istio-egressgateway.type=NodePort"
+  roles:
+    - role: k8s-install-microservice-with-local-helm-chart

--- a/packages/transmute-cli/components/ansible/k8s-install-istio.yml
+++ b/packages/transmute-cli/components/ansible/k8s-install-istio.yml
@@ -16,9 +16,5 @@
         flags: >-
           --set "gateways.istio-ingressgateway.type=NodePort"
           --set "gateways.istio-egressgateway.type=NodePort"
-          --no-crd-hook
-        crds:
-          path: "install/kubernetes/helm/istio/templates/crds.yaml"
-          apply_before_install: yes
   roles:
     - role: k8s-install-microservice-with-local-helm-chart

--- a/packages/transmute-cli/components/ansible/k8s-install-istio.yml
+++ b/packages/transmute-cli/components/ansible/k8s-install-istio.yml
@@ -7,14 +7,17 @@
     microservice:
       name: istio
       namespace: istio-system
-      release:
+      helm:
         dest: "{{ ansible_env.HOME }}/.transmute/git/istio"
         repo: "https://github.com/istio/istio.git"
         version: "1.0.2"
         chart:
           path: "install/kubernetes/helm/istio"
-          flags: >-
-            --set "gateways.istio-ingressgateway.type=NodePort"
-            --set "gateways.istio-egressgateway.type=NodePort"
+        flags: >-
+          --set "gateways.istio-ingressgateway.type=NodePort"
+          --set "gateways.istio-egressgateway.type=NodePort"
+        crds:
+          path: "install/kubernetes/helm/istio/crds.yaml"
+          apply_before_install: yes
   roles:
     - role: k8s-install-microservice-with-local-helm-chart

--- a/packages/transmute-cli/components/ansible/k8s-install-kong.yml
+++ b/packages/transmute-cli/components/ansible/k8s-install-kong.yml
@@ -5,7 +5,7 @@
   vars:
     ipfs_started: no
     ganache_started: no
-    KONG_PROXY_PORT: 32443
+    kong_proxy_port: 32443
   gather_facts: yes
   roles:
     - role: kong

--- a/packages/transmute-cli/components/ansible/roles/ganache-kong-ipfs/tasks/main.yml
+++ b/packages/transmute-cli/components/ansible/roles/ganache-kong-ipfs/tasks/main.yml
@@ -1,125 +1,214 @@
 ---
-- name: KONG_ADMIN_URL
-  shell: "minikube service gateway-kong-admin --url | sed 's,http://,https://,g'"
-  register: KONG_ADMIN_URL
+- name: Initialize helm_release_status
+  set_fact:
+    helm_release_status: "{{ helm_release_status | default({}) }}"
 
-- name: KONG_PROXY_URL
-  shell: "minikube service gateway-kong-proxy --url"
-  register: KONG_PROXY_URL
+- name: Checking if Helm release for Kong has status "DEPLOYED"
+  shell: helm list --deployed gateway
+  register: result
+  changed_when: no
+  check_mode: no
 
-- name: KONG_PROXY_PORT
-  shell: "kubectl get service gateway-kong-proxy -o json | jq -r '.spec.ports[0].nodePort'"
-  register: KONG_PROXY_PORT
+- name: Setting helm_release_status.kong
+  set_fact:
+    helm_release_status: "{{ helm_release_status | combine( { 'kong': result }, recursive=True ) }}"
+  changed_when: no
+  when: result
 
-- name: KONG_HOST
-  shell: "echo {{ KONG_ADMIN_URL.stdout }} | sed 's!https://!!g' | cut -f1 -d:"
-  register: KONG_HOST
+- name: Setting kong_admin_url
+  shell: minikube service gateway-kong-admin --url | sed "s|http://|https://|"
+  register: kong_admin_url
+  changed_when: no
+  check_mode: no
+  when: helm_release_status.kong
 
-- name: KONG_PORT
-  shell: "echo {{ KONG_ADMIN_URL.stdout }} | sed 's!https://!!g' | cut -f2 -d:"
-  register: KONG_PORT
+- name: Setting kong_admin_host
+  shell: minikube service gateway-kong-admin --format "{{ '{{' }} .IP {{ '}}' }}"
+  register: kong_admin_host
+  changed_when: no
+  check_mode: no
+  when: helm_release_status.kong
 
-- name: GANACHE_CLUSTER_IP
-  shell: "kubectl get service ganache -o json | jq -r '.spec.clusterIP'"
-  register: GANACHE_CLUSTER_IP
+- name: Setting kong_admin_port
+  shell: kubectl get service gateway-kong-admin -o json | jq -r ".spec.ports[0].nodePort"
+  register: kong_admin_port
+  changed_when: no
+  check_mode: no
+  when: helm_release_status.kong
 
-- name: "wait for kong to come up"
+- name: Setting kong_proxy_url
+  shell: minikube service gateway-kong-proxy --url
+  register: kong_proxy_url
+  changed_when: no
+  check_mode: no
+  when: helm_release_status.kong
+
+- name: Setting kong_proxy_port
+  shell: kubectl get service gateway-kong-proxy -o json | jq -r ".spec.ports[0].nodePort"
+  register: kong_proxy_port
+  changed_when: no
+  check_mode: no
+  when: helm_release_status.kong
+
+- name: Waiting for Kong to response with HTTP status code "200"
   uri:
-    url: "https://{{ KONG_HOST.stdout }}:{{ KONG_PORT.stdout }}"
+    url: "https://{{ kong_admin_host.stdout }}:{{ kong_admin_port.stdout }}"
     status_code: 200
     validate_certs: no
-  register: result
+  register: request
   retries: 60
   delay: 5
-  register: result
-  until: result.status == 200
+  until: request.status == 200
+  when: helm_release_status.kong
 
-- name: Curl ganache cluster to kong
+- name: Checking if Helm release for Ganache has status "DEPLOYED"
+  shell: helm list --deployed ganache
+  register: result
+  changed_when: no
+  check_mode: no
+
+- name: Setting helm_release_status.ganache
+  set_fact:
+    helm_release_status: "{{ helm_release_status | combine( { 'ganache': result }, recursive=True ) }}"
+  changed_when: no
+  when: result
+
+- name: Setting ganache_cluster_ip
+  shell: kubectl get service ganache -o json | jq -r ".spec.clusterIP"
+  register: ganache_cluster_ip
+  changed_when: no
+  check_mode: no
+  when: helm_release_status.ganache
+
+- name: Adding Ganache to Kong APIs
   uri:
-    url: "{{ KONG_ADMIN_URL.stdout }}/apis/"
+    url: "{{ kong_admin_url.stdout }}/apis/"
     method: POST
-    body: "name=ganache&hosts=ganache.transmute.minikube&upstream_url=http://{{ GANACHE_CLUSTER_IP.stdout }}:8545/"
+    body: "name=ganache&hosts=ganache.transmute.minikube&upstream_url=http://{{ ganache_cluster_ip.stdout }}:8545/"
     validate_certs: no
-  register: result
-  ignore_errors: True
+  register: request
+  ignore_errors: yes
+  when:
+    - helm_release_status.kong
+    - helm_release_status.ganache
 
-- fail: msg="The execution has failed because of errors."
-  when: result.status != 201 and result.status != 409
+- fail:
+    msg: "The execution has failed because of errors."
+  ignore_errors: yes
+  when:
+    - request.status != 201
+    - request.status != 409
 
-- name: GANACHE HEALTHCHECK
+- name: Checking if Ganache is available through Kong proxy
   uri:
-    url: "http://ganache.transmute.minikube:{{ KONG_PROXY_PORT.stdout }}"
+    url: "http://ganache.transmute.minikube:{{ kong_proxy_port.stdout }}"
     method: POST
     body: '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":68}'
     body_format: json
     status_code: 200
-  register: out
-  retries: 5
+  register: request
   delay: 60
+  retries: 5
+  until: request.status == 200
+  when: helm_release_status.ganache
+
+- name: Checking if Helm release for IPFS has status "DEPLOYED"
+  shell: helm list --deployed decentralized-storage
   register: result
-  until: result.status == 200
+  changed_when: no
+  check_mode: no
 
-- name: IPFS_CLUSTER_IP
-  shell: "PATH=$HOME/.transmute/bin:$PATH kubectl get service decentralized-storage-ipfs -o json | jq -r '.spec.clusterIP'"
-  register: IPFS_CLUSTER_IP
+- name: Setting helm_release_status.ipfs
+  set_fact:
+    helm_release_status: "{{ helm_release_status | combine( { 'ipfs': result }, recursive=True ) }}"
+  changed_when: no
+  when: result
 
-- name: Curl ipfs cluster to kong
+- name: Setting ipfs_cluster_ip
+  shell: kubectl get service decentralized-storage-ipfs -o json | jq -r ".spec.clusterIP"
+  register: ipfs_cluster_ip
+  changed_when: no
+  check_mode: no
+  when: helm_release_status.ipfs
+
+- name: Adding IPFS to Kong APIs
   uri:
-    url: "{{ KONG_ADMIN_URL.stdout }}/apis/"
+    url: "{{ kong_admin_url.stdout }}/apis"
     method: POST
-    body: "name=ipfs&hosts=ipfs.transmute.minikube&upstream_url=http://{{ IPFS_CLUSTER_IP.stdout }}:5001/"
+    body: "name=ipfs&hosts=ipfs.transmute.minikube&upstream_url=http://{{ ipfs_cluster_ip.stdout }}:5001/"
     validate_certs: no
-  register: result
-  ignore_errors: True
+  register: adding_ipfs_to_kong_apis_request
+  ignore_errors: yes
+  when: helm_release_status.kong and helm_release_status.ipfs
 
-- fail: msg="The execution has failed because of errors."
-  when: result.status != 201 and result.status != 409
+- fail:
+    msg: "The execution has failed because of errors."
+  ignore_errors: yes
+  when:
+    - helm_release_status.kong
+    - helm_release_status.ipfs
+    - ipfs_cluster_ip
+    - (adding_ipfs_to_kong_apis_request.status != 201) or
+      (adding_ipfs_to_kong_apis_request.status != 409)
 
-- name: Curl ipfs to kong
+- name: Adding CORS plugin to IPFS Kong API
   uri:
-    url: "{{ KONG_ADMIN_URL.stdout }}/apis/ipfs/plugins"
+    url: "{{ kong_admin_url.stdout }}/apis/ipfs/plugins"
     method: POST
-    body: 'name=cors&config.origins=*&config.methods=GET, PUT, POST'
+    body: "name=cors&config.origins=*&config.methods=GET, PUT, POST"
     status_code: 201
     validate_certs: no
-  register: result
-  ignore_errors: True
+  register: adding_cors_plugin_to_ipfs_kong_api_request
+  ignore_errors: yes
+  when:
+    - helm_release_status.kong
+    - helm_release_status.ipfs
+    - (adding_cors_plugin_to_ipfs_kong_api_request.status == 200) or
+      (adding_cors_plugin_to_ipfs_kong_api_request.status == 409)
 
-- fail: msg="The execution has failed because of errors."
-  when: result.status != 201 and result.status != 409
+- fail:
+    msg: "The execution has failed because of errors."
+  when:
+    - helm_release_status.kong
+    - helm_release_status.ipfs
+    - adding_cors_plugin_to_ipfs_kong_api_request.status != 201
+    - adding_cors_plugin_to_ipfs_kong_api_request.status != 409
 
-- name: Curl ipfs get api id
+- name: Adding IPFS API ID to IPFS API
   uri:
-    url: "http://ipfs.transmute.minikube:{{ KONG_PROXY_PORT.stdout }}/api/v0/id"
+    url: "http://ipfs.transmute.minikube:{{ kong_proxy_port.stdout }}/api/v0/id"
     method: GET
-  register: out
+  register: request
   retries: 200
   delay: 1
+  when:
+    - helm_release_status.kong
+    - helm_release_status.ipfs
 
-- name: create dirs
+- name: Ensuring transmute-config directories exist
   file:
-    path: "{{ item }}"
+    path: "{{ ansible_env.HOME }}/.transmute/git/transmute/packages/{{ item }}/src/transmute-config"
     state: directory
     recurse: yes
   with_items:
-    - "{{ ansible_env.HOME }}/.transmute/git/transmute/packages/transmute-framework/src/transmute-config/"
-    - "{{ ansible_env.HOME }}/.transmute/git/transmute/packages/transmute-dashboard/src/transmute-config/"
+    - "transmute-framework"
+    - "transmute-dashboard"
 
-- name: FRAMEWORK_CONFIG
+- name: Adding Transmute Framework template
   template:
     src: framework.env.json.j2
     dest: "{{ ansible_env.HOME }}/.transmute/git/transmute/packages/transmute-framework/src/transmute-config/env.json"
 
-- name: DASHBOARD_CONFIG
+- name: Adding Transmute Dashboard template
   template:
     src: dashboard.env.json.j2
     dest: "{{ ansible_env.HOME }}/.transmute/git/transmute/packages/transmute-dashboard/src/transmute-config/env.json"
 
-- name: TRANSMUTE_ENV
+- name: Ensuring export of TRANSMUTE_ENV environment variable
   lineinfile:
     path: "{{ ansible_env.HOME }}/.bashrc"
     state: present
-    line: 'export {{ item.var }}={{ item.value }}'
+    line: "export {{ item.var }}={{ item.value }}"
   with_items:
     - var: "TRANSMUTE_ENV"
-      value: 'minikube'
+      value: "minikube"

--- a/packages/transmute-cli/components/ansible/roles/ganache-kong-ipfs/tasks/main.yml
+++ b/packages/transmute-cli/components/ansible/roles/ganache-kong-ipfs/tasks/main.yml
@@ -3,75 +3,69 @@
   set_fact:
     helm_release_status: "{{ helm_release_status | default({}) }}"
 
-- name: Checking if Helm release for Kong has status "DEPLOYED"
+- name: Checking Helm release status of Kong
   shell: helm list --deployed gateway
-  register: result
+  register: helm_release_status_kong_check
   changed_when: no
   check_mode: no
 
 - name: Setting helm_release_status.kong
   set_fact:
-    helm_release_status: "{{ helm_release_status | combine( { 'kong': result }, recursive=True ) }}"
+    helm_release_status: "{{ helm_release_status | combine( { 'kong': helm_release_status_kong_check }, recursive=True ) }}"
   changed_when: no
-  when: result
+  when: helm_release_status_kong_check
 
-- name: Setting kong_admin_url
-  shell: minikube service gateway-kong-admin --url | sed "s|http://|https://|"
-  register: kong_admin_url
-  changed_when: no
-  check_mode: no
+- name: Getting Kong service details
+  block:
+    - name: Setting kong_admin_url
+      shell: minikube service gateway-kong-admin --url | sed "s|http://|https://|"
+      register: kong_admin_url
+      changed_when: no
+      check_mode: no
+    - name: Setting kong_admin_host
+      shell: minikube service gateway-kong-admin --format "{{ '{{' }} .IP {{ '}}' }}"
+      register: kong_admin_host
+      changed_when: no
+      check_mode: no
+    - name: Setting kong_admin_port
+      shell: kubectl get service gateway-kong-admin -o json | jq -r ".spec.ports[0].nodePort"
+      register: kong_admin_port
+      changed_when: no
+      check_mode: no
+    - name: Setting kong_proxy_url
+      shell: minikube service gateway-kong-proxy --url
+      register: kong_proxy_url
+      changed_when: no
+      check_mode: no
+    - name: Setting kong_proxy_port
+      shell: kubectl get service gateway-kong-proxy -o json | jq -r ".spec.ports[0].nodePort"
+      register: kong_proxy_port
+      changed_when: no
+      check_mode: no
   when: helm_release_status.kong
 
-- name: Setting kong_admin_host
-  shell: minikube service gateway-kong-admin --format "{{ '{{' }} .IP {{ '}}' }}"
-  register: kong_admin_host
-  changed_when: no
-  check_mode: no
-  when: helm_release_status.kong
-
-- name: Setting kong_admin_port
-  shell: kubectl get service gateway-kong-admin -o json | jq -r ".spec.ports[0].nodePort"
-  register: kong_admin_port
-  changed_when: no
-  check_mode: no
-  when: helm_release_status.kong
-
-- name: Setting kong_proxy_url
-  shell: minikube service gateway-kong-proxy --url
-  register: kong_proxy_url
-  changed_when: no
-  check_mode: no
-  when: helm_release_status.kong
-
-- name: Setting kong_proxy_port
-  shell: kubectl get service gateway-kong-proxy -o json | jq -r ".spec.ports[0].nodePort"
-  register: kong_proxy_port
-  changed_when: no
-  check_mode: no
-  when: helm_release_status.kong
-
-- name: Waiting for Kong to response with HTTP status code "200"
+- name: Waiting for Kong response
   uri:
     url: "https://{{ kong_admin_host.stdout }}:{{ kong_admin_port.stdout }}"
     status_code: 200
     validate_certs: no
-  register: request
+  register: waiting_for_kong_response_request
   retries: 60
   delay: 5
-  until: request.status == 200
+  until: waiting_for_kong_response_request.status == 200
   when: helm_release_status.kong
 
-- name: Checking if Helm release for Ganache has status "DEPLOYED"
+- name: Checking Helm release status of Ganache
   shell: helm list --deployed ganache
-  register: result
+  register: helm_release_status_ganache_check
   changed_when: no
   check_mode: no
 
 - name: Setting helm_release_status.ganache
   set_fact:
-    helm_release_status: "{{ helm_release_status | combine( { 'ganache': result }, recursive=True ) }}"
+    helm_release_status: "{{ helm_release_status | combine( { 'ganache': helm_release_status_ganache_check }, recursive=True ) }}"
   changed_when: no
-  when: result
+  when: helm_release_status_ganache_check
 
 - name: Setting ganache_cluster_ip
   shell: kubectl get service ganache -o json | jq -r ".spec.clusterIP"
@@ -81,23 +75,24 @@
   when: helm_release_status.ganache
 
 - name: Adding Ganache to Kong APIs
-  uri:
-    url: "{{ kong_admin_url.stdout }}/apis/"
-    method: POST
-    body: "name=ganache&hosts=ganache.transmute.minikube&upstream_url=http://{{ ganache_cluster_ip.stdout }}:8545/"
-    validate_certs: no
-  register: request
-  ignore_errors: yes
+  block:
+    - uri:
+        url: "{{ kong_admin_url.stdout }}/apis/"
+        method: POST
+        body: "name=ganache&hosts=ganache.transmute.minikube&upstream_url=http://{{ ganache_cluster_ip.stdout }}:8545/"
+        status_code: 201
+        validate_certs: no
+      register: adding_ganache_to_kong_apis
+      ignore_errors: yes
+    - fail:
+        msg: "The execution has failed because of errors."
+      ignore_errors: yes
+      when:
+        - adding_ganache_to_kong_apis.status != 201
+        - adding_ganache_to_kong_apis.status != 409
   when:
     - helm_release_status.kong
     - helm_release_status.ganache
-
-- fail:
-    msg: "The execution has failed because of errors."
-  ignore_errors: yes
-  when:
-    - request.status != 201
-    - request.status != 409
 
 - name: Checking if Ganache is available through Kong proxy
   uri:
@@ -106,23 +101,25 @@
     body: '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":68}'
     body_format: json
     status_code: 200
-  register: request
+  register: checking_ganache_availability_through_kong_proxy
   delay: 60
   retries: 5
-  until: request.status == 200
-  when: helm_release_status.ganache
+  until: checking_ganache_availability_through_kong_proxy.status == 200
+  when:
+    - helm_release_status.kong
+    - helm_release_status.ganache
 
-- name: Checking if Helm release for IPFS has status "DEPLOYED"
+- name: Checking Helm release status of IPFS
   shell: helm list --deployed decentralized-storage
-  register: result
+  register: helm_release_status_ipfs_check
   changed_when: no
   check_mode: no
 
 - name: Setting helm_release_status.ipfs
   set_fact:
-    helm_release_status: "{{ helm_release_status | combine( { 'ipfs': result }, recursive=True ) }}"
+    helm_release_status: "{{ helm_release_status | combine( { 'ipfs': helm_release_status_ipfs_check }, recursive=True ) }}"
   changed_when: no
-  when: result
+  when: helm_release_status_ipfs_check
 
 - name: Setting ipfs_cluster_ip
   shell: kubectl get service decentralized-storage-ipfs -o json | jq -r ".spec.clusterIP"
@@ -132,60 +129,54 @@
   when: helm_release_status.ipfs
 
 - name: Adding IPFS to Kong APIs
-  uri:
-    url: "{{ kong_admin_url.stdout }}/apis"
-    method: POST
-    body: "name=ipfs&hosts=ipfs.transmute.minikube&upstream_url=http://{{ ipfs_cluster_ip.stdout }}:5001/"
-    validate_certs: no
-  register: adding_ipfs_to_kong_apis_request
-  ignore_errors: yes
-  when: helm_release_status.kong and helm_release_status.ipfs
-
-- fail:
-    msg: "The execution has failed because of errors."
-  ignore_errors: yes
+  block:
+    - uri:
+        url: "{{ kong_admin_url.stdout }}/apis"
+        method: POST
+        body: "name=ipfs&hosts=ipfs.transmute.minikube&upstream_url=http://{{ ipfs_cluster_ip.stdout }}:5001/"
+        status_code: 201
+        validate_certs: no
+      register: adding_ipfs_to_kong_apis_request
+      ignore_errors: yes
+    - fail:
+        msg: "The execution has failed because of errors."
+      when:
+        - adding_ipfs_to_kong_apis_request.status != 201
+        - adding_ipfs_to_kong_apis_request.status != 409
   when:
     - helm_release_status.kong
     - helm_release_status.ipfs
     - ipfs_cluster_ip
-    - (adding_ipfs_to_kong_apis_request.status != 201) or
-      (adding_ipfs_to_kong_apis_request.status != 409)
 
-- name: Adding CORS plugin to IPFS Kong API
-  uri:
-    url: "{{ kong_admin_url.stdout }}/apis/ipfs/plugins"
-    method: POST
-    body: "name=cors&config.origins=*&config.methods=GET, PUT, POST"
-    status_code: 201
-    validate_certs: no
-  register: adding_cors_plugin_to_ipfs_kong_api_request
-  ignore_errors: yes
+- block:
+    - name: Adding CORS plugin to IPFS Kong API
+      uri:
+        url: "{{ kong_admin_url.stdout }}/apis/ipfs/plugins"
+        method: POST
+        body: "name=cors&config.origins=*&config.methods=GET, PUT, POST"
+        status_code: 201
+        validate_certs: no
+      register: adding_cors_plugin_to_ipfs_kong_api_request
+      ignore_errors: yes
+    - fail:
+        msg: "The execution has failed because of errors."
+      when:
+        - adding_cors_plugin_to_ipfs_kong_api_request.status != 201
+        - adding_cors_plugin_to_ipfs_kong_api_request.status != 409
+    - name: Getting IPFS API ID from IPFS API
+      uri:
+        url: "http://ipfs.transmute.minikube:{{ kong_proxy_port.stdout }}/api/v0/id"
+        method: GET
+      register: ipfs_api_id
+      retries: 200
+      delay: 1
+      when:
+        - (adding_ipfs_to_kong_apis_request.status == 200) or
+          (adding_ipfs_to_kong_apis_request.status == 409)
   when:
     - helm_release_status.kong
     - helm_release_status.ipfs
-    - (adding_ipfs_to_kong_apis_request.status == 200) or
-      (adding_ipfs_to_kong_apis_request.status == 409)
-
-- fail:
-    msg: "The execution has failed because of errors."
-  when:
-    - helm_release_status.kong
-    - helm_release_status.ipfs
-    - adding_cors_plugin_to_ipfs_kong_api_request.status != 201
-    - adding_cors_plugin_to_ipfs_kong_api_request.status != 409
-
-- name: Adding IPFS API ID to IPFS API
-  uri:
-    url: "http://ipfs.transmute.minikube:{{ kong_proxy_port.stdout }}/api/v0/id"
-    method: GET
-  register: request
-  retries: 200
-  delay: 1
-  when:
-    - helm_release_status.kong
-    - helm_release_status.ipfs
-    - (adding_ipfs_to_kong_apis_request.status == 200) or
-      (adding_ipfs_to_kong_apis_request.status == 409)
+    - adding_ipfs_to_kong_apis_request
 
 - name: Ensuring transmute-config directories exist
   file:

--- a/packages/transmute-cli/components/ansible/roles/ganache-kong-ipfs/tasks/main.yml
+++ b/packages/transmute-cli/components/ansible/roles/ganache-kong-ipfs/tasks/main.yml
@@ -163,8 +163,8 @@
   when:
     - helm_release_status.kong
     - helm_release_status.ipfs
-    - (adding_cors_plugin_to_ipfs_kong_api_request.status == 200) or
-      (adding_cors_plugin_to_ipfs_kong_api_request.status == 409)
+    - (adding_ipfs_to_kong_apis_request.status == 200) or
+      (adding_ipfs_to_kong_apis_request.status == 409)
 
 - fail:
     msg: "The execution has failed because of errors."
@@ -184,6 +184,8 @@
   when:
     - helm_release_status.kong
     - helm_release_status.ipfs
+    - (adding_ipfs_to_kong_apis_request.status == 200) or
+      (adding_ipfs_to_kong_apis_request.status == 409)
 
 - name: Ensuring transmute-config directories exist
   file:

--- a/packages/transmute-cli/components/ansible/roles/ganache-kong-ipfs/templates/dashboard.env.json.j2
+++ b/packages/transmute-cli/components/ansible/roles/ganache-kong-ipfs/templates/dashboard.env.json.j2
@@ -20,11 +20,11 @@
     },
     "ipfsConfig": {
       "host": "ipfs.transmute.minikube",
-      "port": {{ KONG_PROXY_PORT.stdout }},
+      "port": {{ kong_proxy_port.stdout }},
       "protocol": "http"
     },
     "web3Config": {
-      "providerUrl": "http://ganache.transmute.minikube:{{ KONG_PROXY_PORT.stdout }}"
+      "providerUrl": "http://ganache.transmute.minikube:{{ kong_proxy_port.stdout }}"
     }
   },
   "transmute.network": {

--- a/packages/transmute-cli/components/ansible/roles/ganache-kong-ipfs/templates/framework.env.json.j2
+++ b/packages/transmute-cli/components/ansible/roles/ganache-kong-ipfs/templates/framework.env.json.j2
@@ -20,11 +20,11 @@
     },
     "ipfsConfig": {
       "host": "ipfs.transmute.minikube",
-      "port": {{ KONG_PROXY_PORT.stdout }},
+      "port": {{ kong_proxy_port.stdout }},
       "protocol": "http"
     },
     "web3Config": {
-      "providerUrl": "http://ganache.transmute.minikube:{{ KONG_PROXY_PORT.stdout }}"
+      "providerUrl": "http://ganache.transmute.minikube:{{ kong_proxy_port.stdout }}"
     }
   },
   "transmute.network": {

--- a/packages/transmute-cli/components/ansible/roles/ganache/tasks/main.yml
+++ b/packages/transmute-cli/components/ansible/roles/ganache/tasks/main.yml
@@ -32,4 +32,4 @@
   register: output
 
 - set_fact:
-  ipfs_started: "{{ output.stdout }}"
+    ipfs_started: "{{ output.stdout }}"

--- a/packages/transmute-cli/components/ansible/roles/k8s-install-microservice-with-local-helm-chart/tasks/main.yml
+++ b/packages/transmute-cli/components/ansible/roles/k8s-install-microservice-with-local-helm-chart/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Cloning {{ microservice.name | capitalize }} ({{ microservice.release.repo }}, {{ microservice.release.version }}) into {{ microservice.release.dest }}
+  git:
+    repo: "{{ microservice.release.repo }}"
+    dest: "{{ microservice.release.dest }}"
+    version: "{{ microservice.release.version }}"
+    accept_hostkey: yes
+    depth: 1
+
+- name: Checking if Helm release {{ microservice.name }} has status "DEPLOYED"
+  shell: helm list --deployed "{{ '^' + microservice.name + '$' }}"
+  register: helm_release_status_is_deployed
+  changed_when: False
+  check_mode: no
+
+- name: Installing {{ microservice.name | capitalize }} from Helm chart
+  when: helm_release_status_is_deployed.stdout == ""
+  shell: >
+    helm install "{{ microservice.release.dest + '/' + microservice.release.chart.path }}"
+    --name "{{ microservice.name }}"
+    --namespace "{{ microservice.namespace }}"
+    {{ microservice.release.chart.flags }}
+
+- name: Wait for {{ microservice.name | capitalize }} to be ready
+  shell: "$(npm root -g)/transmute-cli/scripts/w8s/ready.w8 istio istio-system"
+  when: helm_release_status_is_deployed.stdout == ""

--- a/packages/transmute-cli/components/ansible/roles/k8s-install-microservice-with-local-helm-chart/tasks/main.yml
+++ b/packages/transmute-cli/components/ansible/roles/k8s-install-microservice-with-local-helm-chart/tasks/main.yml
@@ -14,9 +14,6 @@
   check_mode: no
 
 - block:
-    - name: Applying {{ microservice.name | capitalize }} CRDs before install
-      shell: kubectl apply -f "{{ microservice.helm.dest + '/' + microservice.helm.crds.path }}"
-      when: microservice.helm.crds.apply_before_install
     - name: Installing {{ microservice.name | capitalize }} with local Helm chart
       shell: >
         helm install "{{ microservice.helm.dest + '/' + microservice.helm.chart.path }}"

--- a/packages/transmute-cli/components/ansible/roles/k8s-install-microservice-with-local-helm-chart/tasks/main.yml
+++ b/packages/transmute-cli/components/ansible/roles/k8s-install-microservice-with-local-helm-chart/tasks/main.yml
@@ -1,26 +1,29 @@
 ---
-- name: Cloning {{ microservice.name | capitalize }} ({{ microservice.release.repo }}, {{ microservice.release.version }}) into {{ microservice.release.dest }}
+- name: Cloning {{ microservice.name | capitalize }} ({{ microservice.helm.repo }}, {{ microservice.helm.version }}) into {{ microservice.helm.dest }}
   git:
-    repo: "{{ microservice.release.repo }}"
-    dest: "{{ microservice.release.dest }}"
-    version: "{{ microservice.release.version }}"
+    repo: "{{ microservice.helm.repo }}"
+    dest: "{{ microservice.helm.dest }}"
+    version: "{{ microservice.helm.version }}"
     accept_hostkey: yes
     depth: 1
 
-- name: Checking if Helm release {{ microservice.name }} has status "DEPLOYED"
-  shell: helm list --deployed "{{ '^' + microservice.name + '$' }}"
-  register: helm_release_status_is_deployed
-  changed_when: False
+- name: Checking Helm release status of {{ microservice.name }}
+  shell: helm list --deployed "^{{ microservice.name }}$"
+  register: helm_release_status_check
+  changed_when: no
   check_mode: no
 
-- name: Installing {{ microservice.name | capitalize }} from Helm chart
-  when: helm_release_status_is_deployed.stdout == ""
-  shell: >
-    helm install "{{ microservice.release.dest + '/' + microservice.release.chart.path }}"
-    --name "{{ microservice.name }}"
-    --namespace "{{ microservice.namespace }}"
-    {{ microservice.release.chart.flags }}
-
-- name: Wait for {{ microservice.name | capitalize }} to be ready
-  shell: "$(npm root -g)/transmute-cli/scripts/w8s/ready.w8 istio istio-system"
-  when: helm_release_status_is_deployed.stdout == ""
+- block:
+    - name: Applying {{ microservice.name | capitalize }} CRDs before install
+      shell: kubectl apply -f "{{ microservice.helm.dest + '/' + microservice.helm.crds.path }}"
+      when: microservice.helm.crds.apply_before_install
+    - name: Installing {{ microservice.name | capitalize }} with local Helm chart
+      shell: >
+        helm install "{{ microservice.helm.dest + '/' + microservice.helm.chart.path }}"
+        --name "{{ microservice.name }}"
+        --namespace "{{ microservice.namespace }}"
+        {{ microservice.helm.flags }}
+    - name: Wait for {{ microservice.name | capitalize }} to be ready
+      shell: "$(npm root -g)/transmute-cli/scripts/w8s/ready.w8 istio istio-system"
+      changed_when: no
+  when: helm_release_status_check.stdout == ""

--- a/packages/transmute-cli/components/ansible/roles/kong/tasks/main.yml
+++ b/packages/transmute-cli/components/ansible/roles/kong/tasks/main.yml
@@ -4,7 +4,7 @@
   register: output
 
 - name: Install kong
-  shell: "helm install stable/kong --name gateway --set proxy.useTLS=false --set proxy.nodePort={{ KONG_PROXY_PORT }} --wait"
+  shell: "helm install stable/kong --name gateway --set proxy.useTLS=false --set proxy.nodePort={{ kong_proxy_port }} --wait"
   when: not output.stdout
 
 - name: spin up

--- a/packages/transmute-cli/components/ansible/roles/minikube/tasks/main.yml
+++ b/packages/transmute-cli/components/ansible/roles/minikube/tasks/main.yml
@@ -1,25 +1,19 @@
 ---
-
-- name: start minikube
+- name: Start Minikube cluster
   shell: "sudo minikube start  --kubernetes-version {{ kubernetes_version }} --disk-size {{ minikube_disk_size }} --cpus {{ minikube_cpus }} --memory {{ minikube_memory }} --vm-driver={{ minikube_vm_driver }}"
   when: minikube_vm_driver == "none"
 
-- name: setting access
+- name: Ensuring ownership of minikube and kube user configuration files
   file:
-    path: "{{ ansible_env.HOME }}/.kube"
+    path: "{{ ansible_env.HOME }}{{ item }}"
     owner: "{{ ansible_env.USER }}"
     recurse: yes
   become: yes
+  with_items:
+    - "/.kube"
+    - "/.minikube"
   when: minikube_vm_driver == "none"
 
-- name: setting access
-  file:
-    path: "{{ ansible_env.HOME }}/.minikube"
-    owner: "{{ ansible_env.USER }}"
-    recurse: yes
-  become: yes
-  when: minikube_vm_driver == "none"
-
-- name: start minikube
+- name: Start Minikube cluster
   shell: "minikube start  --kubernetes-version {{ kubernetes_version }} --disk-size {{ minikube_disk_size }} --cpus {{ minikube_cpus }} --memory {{ minikube_memory }} --vm-driver={{ minikube_vm_driver }}"
   when: minikube_vm_driver != "none"

--- a/packages/transmute-cli/src/commands/microservice/index.js
+++ b/packages/transmute-cli/src/commands/microservice/index.js
@@ -1,5 +1,11 @@
 const run = require('../runner');
-const APPS_NAMES = ['kong', 'ipfs', 'ganache', 'elasticsearch'];
+const APPS_NAMES = [
+  'istio',
+  'kong',
+  'ipfs',
+  'ganache',
+  'elasticsearch'
+];
 
 module.exports.install = (dryrun, appname) => {
   if (APPS_NAMES.indexOf(appname) == -1) {

--- a/packages/transmute-cli/src/commands/provision/index.js
+++ b/packages/transmute-cli/src/commands/provision/index.js
@@ -1,6 +1,6 @@
 const run = require('../runner');
 const logger = require('../../logger');
-const TRANSMUTE_KUBE_VERSION = process.env.TRANSMUTE_KUBE_VERSION || 'v1.9.4';
+const TRANSMUTE_KUBE_VERSION = process.env.TRANSMUTE_KUBE_VERSION || 'v1.11.3';
 const MINIKUBE_CPU = process.env.MINIKUBE_CPU || '4';
 const MINIKUBE_MEMORY = process.env.MINIKUBE_MEMORY || '4096';
 const MINIKUBE_DISK = process.env.MINIKUBE_DISK || '100g';


### PR DESCRIPTION
Adding the k8s microservice Istio to Transmute CLI subcommand `transmute k8s microservice install`.

There are a number of improvements to the Ansible scripts used by Transmute CLI to install microservices in general, as well as a new role meant to be reused as a template of-sorts for other supported microservices.