### PR TITLE
Fix/framework and adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
   # - transmute k8s microservice install istio
   - transmute k8s microservice install kong
   # - transmute k8s microservice install elasticsearch
-  - transmute k8s microservice install ganache -v 2.2.1
+  - transmute k8s microservice install ganache -v 0.1.1
   - transmute k8s microservice install ipfs
   - transmute debug
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
   # - transmute k8s microservice install istio
   - transmute k8s microservice install kong
   # - transmute k8s microservice install elasticsearch
-  - transmute k8s microservice install ganache
+  - transmute k8s microservice install ganache -v 2.2.1
   - transmute k8s microservice install ipfs
   - transmute debug
 

--- a/packages/transmute-adapter-firebase-rtdb/index.js
+++ b/packages/transmute-adapter-firebase-rtdb/index.js
@@ -30,10 +30,9 @@ module.exports = class TransmuteAdapterFirebaseRTDB {
 
   readJson(key) {
     return this.db
-      .ref(this.path)
-      .ref(key)
-      .once()
-      .then(data => data);
+      .ref(`${this.path}${key}`)
+      .once('value')
+      .then(data => data.val());
   }
 
   async writeJson(value) {

--- a/packages/transmute-adapter-firebase-rtdb/package.json
+++ b/packages/transmute-adapter-firebase-rtdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/transmute-adapter-firebase-rtdb",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/transmute-cli/src/commands/microservice/index.js
+++ b/packages/transmute-cli/src/commands/microservice/index.js
@@ -47,5 +47,6 @@ module.exports.install = (dryrun, microservice, version) => {
     deployCommand += ' --check';
   }
 
+  console.log(deployCommand);
   run.shellExec(deployCommand);
 };

--- a/packages/transmute-cli/src/commands/microservice/index.js
+++ b/packages/transmute-cli/src/commands/microservice/index.js
@@ -14,7 +14,7 @@ const MICROSERVICE_VERSIONS = {
   istio: '1.0.2',
   kong: '',
   ipfs: '',
-  ganache: '2.2.1',
+  ganache: '',
   elasticsearch: '',
 };
 
@@ -47,6 +47,5 @@ module.exports.install = (dryrun, microservice, version) => {
     deployCommand += ' --check';
   }
 
-  console.log(deployCommand);
   run.shellExec(deployCommand);
 };

--- a/packages/transmute-cli/src/commands/microservice/index.js
+++ b/packages/transmute-cli/src/commands/microservice/index.js
@@ -14,7 +14,7 @@ const MICROSERVICE_VERSIONS = {
   istio: '1.0.2',
   kong: '',
   ipfs: '',
-  ganache: '',
+  ganache: '2.2.1',
   elasticsearch: '',
 };
 

--- a/packages/transmute-framework/package.json
+++ b/packages/transmute-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/transmute-framework",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Event Sourced Decentralized Application Development Framework.",
   "main": "src/index.js",
   "files": [

--- a/packages/transmute-framework/package.json
+++ b/packages/transmute-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/transmute-framework",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Event Sourced Decentralized Application Development Framework.",
   "main": "src/index.js",
   "files": [

--- a/packages/transmute-framework/src/event-store-factory/index.js
+++ b/packages/transmute-framework/src/event-store-factory/index.js
@@ -5,7 +5,6 @@
 
 const contract = require('truffle-contract');
 const pack = require('../../package.json');
-const GAS = require('../gas');
 
 /** @class EventStoreFactory */
 module.exports = class EventStoreFactory {
@@ -75,7 +74,6 @@ module.exports = class EventStoreFactory {
   async clone(fromAddress) {
     const newContract = await this.eventStoreFactoryContract.new({
       from: fromAddress,
-      gas: GAS.MAX_GAS,
     });
     const instance = Object.assign(
       Object.create(Object.getPrototypeOf(this)),
@@ -97,7 +95,6 @@ module.exports = class EventStoreFactory {
     this.requireInstance();
     return this.eventStoreFactoryContractInstance.createEventStore({
       from: fromAddress,
-      gas: GAS.MAX_GAS,
     });
   }
 
@@ -124,9 +121,9 @@ module.exports = class EventStoreFactory {
    */
   async destroy(fromAddress, address) {
     this.requireInstance();
-    return this.eventStoreFactoryContractInstance.destroy(address, {
-      from: fromAddress,
-      gas: GAS.MAX_GAS,
-    });
+    return this.eventStoreFactoryContractInstance.destroy(
+      address,
+      { from: fromAddress },
+    );
   }
 };

--- a/packages/transmute-framework/src/event-store/index.js
+++ b/packages/transmute-framework/src/event-store/index.js
@@ -5,7 +5,6 @@
 
 const contract = require('truffle-contract');
 const pack = require('../../package.json');
-const GAS = require('../gas');
 
 /** @class EventStore */
 module.exports = class EventStore {
@@ -79,7 +78,6 @@ module.exports = class EventStore {
   async clone(fromAddress) {
     const newContract = await this.eventStoreContract.new({
       from: fromAddress,
-      gas: GAS.MAX_GAS,
     });
     const instance = Object.assign(
       Object.create(Object.getPrototypeOf(this)),
@@ -124,11 +122,7 @@ module.exports = class EventStore {
 
     const tx = await eventStoreContractInstance.write(
       contentHash,
-      {
-        from: fromAddress,
-        // TODO: remove
-        gas: GAS.EVENT_GAS_COST,
-      },
+      { from: fromAddress },
     );
     const { index } = tx.logs[0].args;
 

--- a/packages/transmute-framework/src/event-store/index.js
+++ b/packages/transmute-framework/src/event-store/index.js
@@ -90,21 +90,6 @@ module.exports = class EventStore {
   }
 
   /**
-   * Returns transaction receipt
-   * @function
-   * @memberof EventStore
-   * @name getTransactionReceipt
-   */
-  async getTransactionReceipt(tx) {
-    return new Promise((resolve, reject) => {
-      this.web3.eth.getTransactionReceipt(tx, (error, result) => {
-        if (!error) resolve(result);
-        else reject(error);
-      });
-    });
-  }
-
-  /**
    * calls writeContent if called with write(fromAddress, content)
    * calls writeKeyValue if called with write(fromAddress, key, value)
    * @function
@@ -146,7 +131,6 @@ module.exports = class EventStore {
       },
     );
     const { index } = tx.logs[0].args;
-    const receipt = await this.getTransactionReceipt(tx);
 
     return {
       event: {
@@ -156,10 +140,6 @@ module.exports = class EventStore {
       },
       meta: {
         tx,
-        contentID: {
-          content,
-        },
-        receipt,
       },
     };
   }

--- a/packages/transmute-framework/src/event-store/index.js
+++ b/packages/transmute-framework/src/event-store/index.js
@@ -130,7 +130,7 @@ module.exports = class EventStore {
       event: {
         sender: fromAddress,
         content,
-        index,
+        index: index.toNumber(),
       },
       meta: {
         tx,

--- a/packages/transmute-framework/src/gas.js
+++ b/packages/transmute-framework/src/gas.js
@@ -1,7 +1,0 @@
-const MAX_GAS = 1000000;
-const EVENT_GAS_COST = 500000;
-
-module.exports = {
-  MAX_GAS,
-  EVENT_GAS_COST,
-};


### PR DESCRIPTION
- Fix readJson function, it didn't work because of lack of tests. Added a Jira ticket to add tests for adapters: https://transmute.atlassian.net/browse/ENG-759
- `getTransactionReceipt` function is deprecated since web3 v1.0, so it's been removed
- Removed  Remove GAS parameter everywhere, since `truffle-contract` is smart enough to estimate gas now
