### PR TITLE
Fix truffle-contract async bug

### DIFF
--- a/packages/transmute-framework/package.json
+++ b/packages/transmute-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/transmute-framework",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Event Sourced Decentralized Application Development Framework.",
   "main": "src/index.js",
   "files": [

--- a/packages/transmute-framework/src/event-store/index.js
+++ b/packages/transmute-framework/src/event-store/index.js
@@ -120,17 +120,15 @@ module.exports = class EventStore {
     const { adapter, eventStoreContractInstance } = this;
     const contentHash = await adapter.writeJson(content);
 
-    const tx = await eventStoreContractInstance.write(
-      contentHash,
-      { from: fromAddress },
-    );
-    const { index } = tx.logs[0].args;
-
+    const tx = await eventStoreContractInstance.contract.methods
+      .write(contentHash)
+      .send({ from: fromAddress });
+    const { index } = tx.events.TransmuteEvent.returnValues;
     return {
       event: {
         sender: fromAddress,
         content,
-        index: index.toNumber(),
+        index: parseInt(index),
       },
       meta: {
         tx,


### PR DESCRIPTION
`await eventStore.write(...)` does not work if truffle-contracts are used, but it does if the web3 contract is used, for some reasons... 